### PR TITLE
Update PatissierJob_de_DE.lang

### DIFF
--- a/PatissierJob_de_DE.lang
+++ b/PatissierJob_de_DE.lang
@@ -15,13 +15,13 @@ staxel.village.dialogue.job.Patissier.line:10000600=🎶I wish I was on yonder h
 //[Reference] 'Oh! Please forgive my tuneless wailing...'
 staxel.village.dialogue.job.Patissier.line:10000700=Oh! Entschuldige mein klangloses Geheul...
 //[Reference] 'I always sing while I'm baking!'
-staxel.village.dialogue.job.Patissier.line:10000800=Ich singer immer, während des Backens!
+staxel.village.dialogue.job.Patissier.line:10000800=Ich singer immer während des Backens!
 //[Reference] 'My apron has been getting a bit worn lately.'
 staxel.village.dialogue.job.Patissier.line:10000900=Meine Schürze nutzt sich in letzter Zeit stark ab.
 //[Reference] 'I should probably think about having a new one made.'
 staxel.village.dialogue.job.Patissier.line:10001000=Ich sollte mir wahrscheinlich eine neue machen lassen.
 //[Reference] 'Maybe a lacy or frilly one?'
-staxel.village.dialogue.job.Patissier.line:10001100=Vielleicht eine spitzenartige oder aufgeputzte?
+staxel.village.dialogue.job.Patissier.line:10001100=Vielleicht eine mit Spitze oder Rüsche?
 //[Reference] '🎶 ...sage, rosemary, and thyme... 🎶'
 staxel.village.dialogue.job.Patissier.line:10001200=🎶 ...sage, rosemary, and thyme... 🎶
 //[Reference] 'No, no. While I do know at least a thousand recipes for strawberry shortcake...'
@@ -33,7 +33,7 @@ staxel.village.dialogue.job.Patissier.line:10001500=Einige Teile meines Backens 
 //[Reference] 'If I don't sing while I work, my pastries don't end up as light and crispy!'
 staxel.village.dialogue.job.Patissier.line:10001600=Wenn ich nicht beim Arbeiten singe, wird mein Gebäck nicht so leicht und knusprig!
 //[Reference] 'It's almost like the songs are charms for making good sweets!'
-staxel.village.dialogue.job.Patissier.line:10001700=Es ist fast so, als ob die Lieder magisch auf gute Süßigkeiten wirkten!
+staxel.village.dialogue.job.Patissier.line:10001700=Es ist fast so, als wären die Lieder wie Zauber für geradezu magische Süßigkeiten!
 //[Reference] 'If you buy an oven you can bake all sorts of things.'
 staxel.village.dialogue.job.Patissier.line:10001800=Wenn du einen Ofen kaufst, kannst du alles Mögliche backen.
 //[Reference] 'There are lots of people in the village who might appreciate it!'
@@ -45,8 +45,8 @@ staxel.village.dialogue.job.Patissier.line:10002100=Ich bin nur eine Person, auc
 //[Reference] 'I'm starting to get tired of baking round macarons.'
 staxel.village.dialogue.job.Patissier.line:10002200=Langsam wird das Backen runder Makronen langweilig.
 //[Reference] 'I think I'll make the next batch heart-shaped.'
-staxel.village.dialogue.job.Patissier.line:10002300=Ich denke, ich werde die nächste Ladung Herz-förmig machen.
+staxel.village.dialogue.job.Patissier.line:10002300=Ich denke, ich werde die nächste Ladung herzförmig machen.
 //[Reference] 'I really want to bake a princess cake, but we don't have any princesses...'
-staxel.village.dialogue.job.Patissier.line:10002400=Ich würde gerne eine Prinsesstårta backen, aber wir haben leide keine Prinzessin...
+staxel.village.dialogue.job.Patissier.line:10002400=Ich würde wirklich gerne eine Prinzessinnentorte backen, aber wir haben leider keine Prinzessin...
 //[Reference] 'Do you think {0-mayor_name} would agree to dress up as one for a day?'
-staxel.village.dialogue.job.Patissier.line:10002500=Denkst du {0-mayor_name} würde einwilligen sich als Prinzessin zu verkleiden für einen Tag?
+staxel.village.dialogue.job.Patissier.line:10002500=Denkst du, {0-mayor_name} würde einwilligen sich für einen Tag als Prinzessin zu verkleiden?


### PR DESCRIPTION
 Prinsesstårta heißt auf deutsch scheinabr auch einfach Prinzessinnentorte, macht den Witz ersichtlicher